### PR TITLE
Add Long Form DID Example

### DIFF
--- a/packages/vc.js/src/__fixtures__/documentLoader.ts
+++ b/packages/vc.js/src/__fixtures__/documentLoader.ts
@@ -15,6 +15,7 @@ const localOverrides: any = {
 export const documentLoader = async (url: string) => {
   // console.log(url);
   const withoutFragment: string = url.split('#')[0];
+
   if (localOverrides[withoutFragment]) {
     return {
       contextUrl: null, // this is for a context via a link header

--- a/packages/vc.js/src/__fixtures__/longFormDidDoc.json
+++ b/packages/vc.js/src/__fixtures__/longFormDidDoc.json
@@ -1,0 +1,40 @@
+{
+  "@context": [
+    "https://w3id.org/did/v0.11",
+    {
+      "@base": "https://long-form-did.example.com/123123123123123123123123123"
+    }
+  ],
+  "id": "https://long-form-did.example.com/123123123123123123123123123",
+  "publicKey": [
+    {
+      "id": "#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "https://long-form-did.example.com/123123123123123123123123123",
+      "publicKeyBase58": "Avp3Y4RKGUHbuRnYEK4PoWLvsgFuPjs5QKSddDRFxLwB"
+    },
+    {
+      "type": "JsonWebKey2020",
+      "id": "#llJtlNS6AEAUd7_cozAN4nWVV2pdubbMa4-gtanKUS0",
+      "controller": "https://long-form-did.example.com/123123123123123123123123123",
+      "publicKeyJwk": {
+        "crv": "Ed25519",
+        "x": "uTMyN-jtj9BwsKsEIaX9dXnW5ZZ_dx_84ZQpgDTGeVA",
+        "kty": "OKP",
+        "kid": "llJtlNS6AEAUd7_cozAN4nWVV2pdubbMa4-gtanKUS0"
+      }
+    }
+  ],
+  "authentication": ["#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"],
+  "assertionMethod": ["#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"],
+  "capabilityDelegation": ["#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"],
+  "capabilityInvocation": ["#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"],
+  "keyAgreement": [
+    {
+      "id": "#zCB8kVS1JUjPux8Hu8QbPWdeTbzuf1RAyko3G7ry1CtyBZ",
+      "type": "X25519KeyAgreementKey2019",
+      "controller": "https://long-form-did.example.com/123123123123123123123123123",
+      "publicKeyBase58": "Be2n4pVHMedX2Evg16pYUUnJkdr3rUNFu9y61tConj5M"
+    }
+  ]
+}

--- a/packages/vc.js/src/__fixtures__/shortFormDidDoc.json
+++ b/packages/vc.js/src/__fixtures__/shortFormDidDoc.json
@@ -1,0 +1,40 @@
+{
+  "@context": [
+    "https://w3id.org/did/v0.11",
+    {
+      "@base": "https://short-form-did.example.com/12"
+    }
+  ],
+  "id": "https://short-form-did.example.com/12",
+  "publicKey": [
+    {
+      "id": "#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ",
+      "type": "Ed25519VerificationKey2018",
+      "controller": "https://short-form-did.example.com/12",
+      "publicKeyBase58": "Avp3Y4RKGUHbuRnYEK4PoWLvsgFuPjs5QKSddDRFxLwB"
+    },
+    {
+      "type": "JsonWebKey2020",
+      "id": "#llJtlNS6AEAUd7_cozAN4nWVV2pdubbMa4-gtanKUS0",
+      "controller": "https://short-form-did.example.com/12",
+      "publicKeyJwk": {
+        "crv": "Ed25519",
+        "x": "uTMyN-jtj9BwsKsEIaX9dXnW5ZZ_dx_84ZQpgDTGeVA",
+        "kty": "OKP",
+        "kid": "llJtlNS6AEAUd7_cozAN4nWVV2pdubbMa4-gtanKUS0"
+      }
+    }
+  ],
+  "authentication": ["#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"],
+  "assertionMethod": ["#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"],
+  "capabilityDelegation": ["#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"],
+  "capabilityInvocation": ["#z6MkpP568Jfkc1n51vdEut2EebtvhFXkod7S6LMZTVPGsZiZ"],
+  "keyAgreement": [
+    {
+      "id": "#zCB8kVS1JUjPux8Hu8QbPWdeTbzuf1RAyko3G7ry1CtyBZ",
+      "type": "X25519KeyAgreementKey2019",
+      "controller": "https://short-form-did.example.com/12",
+      "publicKeyBase58": "Be2n4pVHMedX2Evg16pYUUnJkdr3rUNFu9y61tConj5M"
+    }
+  ]
+}

--- a/packages/vc.js/src/vc-ld/__tests__/long-form-did.sanity.test.ts
+++ b/packages/vc.js/src/vc-ld/__tests__/long-form-did.sanity.test.ts
@@ -1,0 +1,112 @@
+import * as fixtures from '../../__fixtures__';
+import { ld as vcld } from '../../index';
+const jsigs = require('jsonld-signatures');
+const { Ed25519KeyPair } = require('crypto-ld');
+const { Ed25519Signature2018 } = jsigs.suites;
+const firstKey = fixtures.unlockedDid.publicKey[0];
+const key = new Ed25519KeyPair(firstKey);
+const shortForm = 'https://short-form-did.example.com/12';
+const longForm =
+  'https://long-form-did.example.com/123123123123123123123123123';
+
+jest.setTimeout(10 * 1000);
+
+describe('Ed25519Signature2018 LongFormDID', () => {
+  it('short form works as long as short form did documet is "recoverable"', async () => {
+    key.controller = `${shortForm}`;
+    key.id = `${key.controller}#${key.id.split('#').pop()}`;
+
+    const suite = new Ed25519Signature2018({
+      key,
+      date: '2019-12-11T03:50:55Z',
+    });
+    const credential = {
+      ...fixtures.test_vectors.ld.credentialTemplate,
+      issuer: {
+        id: shortForm,
+      },
+      credentialSubject: {
+        ...fixtures.test_vectors.ld.credentialTemplate.credentialSubject,
+        id: fixtures.unlockedDid.id,
+      },
+    };
+    const credentialIssued = await vcld.issue({
+      credential: { ...credential },
+      suite: suite,
+      documentLoader: (url: string) => {
+        return fixtures.documentLoader(url);
+      },
+    });
+
+    const credentialVerified = await vcld.verifyCredential({
+      credential: { ...credentialIssued },
+      // IMPORTANT must pass empty suite to "rely on document loader"
+      // show nothing up my sleave.
+      suite: new Ed25519Signature2018({}),
+      documentLoader: (url: string) => {
+        // issuing from a short form works AS LONG AS
+        // you know how to get a short form document.
+        // this means that anyone who wants to
+        // verify things that are not anchored needs to
+        // retain long form for as long as they need to do that.
+        if (url.split('#')[0] === shortForm) {
+          const shortFormDidDoc = require('../../__fixtures__/shortFormDidDoc.json');
+          return {
+            contextUrl: null,
+            document: shortFormDidDoc,
+            documentUrl: shortFormDidDoc.id,
+          };
+        }
+        return fixtures.documentLoader(url);
+      },
+    });
+    expect(credentialVerified.verified).toBe(true);
+  });
+
+  it('long form only works when its issuer matches did document', async () => {
+    key.controller = `${longForm}`;
+    key.id = `${key.controller}#${key.id.split('#').pop()}`;
+
+    const suite = new Ed25519Signature2018({
+      key,
+      date: '2019-12-11T03:50:55Z',
+    });
+    const credential = {
+      ...fixtures.test_vectors.ld.credentialTemplate,
+      issuer: {
+        id: longForm,
+      },
+      credentialSubject: {
+        ...fixtures.test_vectors.ld.credentialTemplate.credentialSubject,
+        id: fixtures.unlockedDid.id,
+      },
+    };
+    const credentialIssued = await vcld.issue({
+      credential: { ...credential },
+      suite: suite,
+      documentLoader: fixtures.documentLoader,
+    });
+
+    const credentialVerified = await vcld.verifyCredential({
+      credential: { ...credentialIssued },
+      // IMPORTANT must pass empty suite to "rely on document loader"
+      // show nothing up my sleave.
+      suite: new Ed25519Signature2018({}),
+      documentLoader: (url: string) => {
+        // issuing from a "long form", only works if
+        // you verify with a long form did document.
+        if (url.split('#')[0] === longForm) {
+          const longFormDidDoc = require('../../__fixtures__/longFormDidDoc.json');
+          return {
+            contextUrl: null,
+            document: longFormDidDoc,
+            documentUrl: longFormDidDoc.id,
+          };
+        }
+        return fixtures.documentLoader(url);
+      },
+    });
+
+    expect(credentialVerified.verified).toBe(true);
+  });
+});


### PR DESCRIPTION
TL;DR... don't use long form DIDs to issue ever, and any party that wants to verify short form credentials for unanchored DIDs must retain long form forever.